### PR TITLE
Manuals gridview

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -180,7 +180,6 @@ a:not([href]):not([class]):hover {
     border-radius: 10px;
     background-color: var(--info);
     display: block;
-    width: 15vw;
     color: var(--dark);
     text-align: center;
 }
@@ -589,6 +588,14 @@ pre code {
     flex-wrap: wrap;
     margin-right: -15px;
     margin-left: -15px;
+}
+
+.manuals-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 15px;
+    width: 100%;
+    margin-bottom: 20px;
 }
 
 .no-gutters {

--- a/resources/views/pages/manual_list.blade.php
+++ b/resources/views/pages/manual_list.blade.php
@@ -13,7 +13,7 @@
 
     <p>{{ __('introduction_texts.type_list', ['brand'=>$brand->name]) }}</p>
 
-
+<div class="manuals-grid">
     @foreach ($manuals as $manual)
 
         @if ($manual->locally_available)
@@ -22,9 +22,9 @@
         @else
             <a class="manual-button" onclick="trackClick({{ $manual->id }})" href="{{ $manual->url }}" target="new" alt="{{ $manual->name }}" title="{{ $manual->name }}">{{ $manual->name }}</a>
     @endif
-
-    <br />
     @endforeach
+</div>
+
     <script>
         function trackClick(id) {
             fetch("/addView/" + id, {


### PR DESCRIPTION
Alle Manuals zijn nu in een grid view van max 3 items breed per rij.

De manual buttons hebben nu geen vaste width van 15vw gezien dit de grid breekt.

Ook heeft elke grid nu een margin-bottom om de footer wat verder weg te plaatsen